### PR TITLE
Refine email feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # justtesting
 
-This is a small demo project showing how to build a basic website with user sign up and login functionality using only Node's built-in modules.
+This is a small demo project showing how to build a basic website with user sign up and login functionality using only Node's built-in modules. It now includes optional email notifications when new questions are submitted.
 
 ## Running the server
 
@@ -12,4 +12,18 @@ node server.js
 
 The server listens on port 3000 by default. Open your browser and navigate to `http://localhost:3000` to access the site.
 
-User data is stored in `users.json` in the project directory.
+User data is stored in `users.json` in the project directory. When signing up
+you can optionally provide an email address. If provided, the server will send
+notifications about new questions directed at that user when email support is
+configured.
+
+## Email notifications
+
+If you want users to receive an email when someone submits a new question for them, set the following environment variables before starting the server:
+
+```
+MAILGUN_API_KEY=your-api-key
+MAILGUN_DOMAIN=your-domain.example
+```
+
+When these are defined the server will send a message via [Mailgun](https://www.mailgun.com/) each time a question is posted.

--- a/email.js
+++ b/email.js
@@ -1,0 +1,52 @@
+const https = require('https');
+const querystring = require('querystring');
+
+function sendEmail(to, subject, text, callback) {
+  const apiKey = process.env.MAILGUN_API_KEY;
+  const domain = process.env.MAILGUN_DOMAIN;
+  if (!apiKey || !domain) {
+    console.log('Mailgun credentials not set; skipping email');
+    if (callback) callback(new Error('Mailgun credentials not set'));
+    return;
+  }
+
+  const postData = querystring.stringify({
+    from: `noreply@${domain}`,
+    to,
+    subject,
+    text
+  });
+
+  const options = {
+    hostname: 'api.mailgun.net',
+    path: `/v3/${domain}/messages`,
+    method: 'POST',
+    auth: `api:${apiKey}`,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Length': Buffer.byteLength(postData)
+    }
+  };
+
+  const req = https.request(options, (res) => {
+    res.setEncoding('utf8');
+    let data = '';
+    res.on('data', chunk => data += chunk);
+    res.on('end', () => {
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        if (callback) callback(null, data);
+      } else {
+        if (callback) callback(new Error(`Mailgun error: ${res.statusCode} ${data}`));
+      }
+    });
+  });
+
+  req.on('error', (err) => {
+    if (callback) callback(err);
+  });
+
+  req.write(postData);
+  req.end();
+}
+
+module.exports = { sendEmail };


### PR DESCRIPTION
## Summary
- make email optional in user accounts
- trim and store email only if provided
- document optional email in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683c59878878832b85f875f1308fedf9